### PR TITLE
Remove Qt::SystemLocaleShortDate as it is no longer in Qt6

### DIFF
--- a/src/netcatgui.cpp
+++ b/src/netcatgui.cpp
@@ -235,7 +235,7 @@ void NetcatGUI::ncSaveLog()
         QMessageBox::critical(this, "File open error", "The selected file could not be opened for writing.\n Log not saved.");
         return;
     }
-    QString log = "--\n[" + QTime::currentTime().toString(Qt::SystemLocaleShortDate) + " " + QDate::currentDate().toString(Qt::SystemLocaleShortDate)
+    QString log = "--\n[" + QTime::currentTime().toString() + " " + QDate::currentDate().toString()
                   + "]" + "\nNetcatGUI log session for " + static_cast<NcSessionWidget*>(ui->tabWidget->currentWidget())->getSessionName() + "\n---\n" + static_cast<NcSessionWidget*>(ui->tabWidget->currentWidget())->getSessionLog().toLatin1() + "\n-----";
     qint64 bytesWritten = logFile.write(log.toLatin1());
     if( bytesWritten ==  -1)


### PR DESCRIPTION
The documentation says: 

Note: Support for localized dates, including the format options [Qt::SystemLocaleDate](https://doc.qt.io/qt-5/qt.html#DateFormat-enum), [Qt::SystemLocaleShortDate](https://doc.qt.io/qt-5/qt.html#DateFormat-enum), [Qt::SystemLocaleLongDate](https://doc.qt.io/qt-5/qt.html#DateFormat-enum), [Qt::LocaleDate](https://doc.qt.io/qt-5/qt.html#DateFormat-enum), [Qt::DefaultLocaleShortDate](https://doc.qt.io/qt-5/qt.html#DateFormat-enum), and [Qt::DefaultLocaleLongDate](https://doc.qt.io/qt-5/qt.html#DateFormat-enum), shall be removed in Qt 6. Use [QLocale::toDate](https://doc.qt.io/qt-5/qlocale.html#toDate)() instead.

However I wasn't able to find the correct syntax to use in QLocale::toDate so I just removed it. 